### PR TITLE
Added -json-flat

### DIFF
--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -662,15 +662,15 @@ func flattenAndFormatJSON(inputJSON []byte) (*[]string) {
 	
 	// Make a sorted index, so we can print keys in order
 	kIndex := make([]string, len(flattened))
-    ki := 0
-    for key, _ := range flattened {
-        kIndex[ki] = key
-        ki++
-    }
-    sort.Strings(kIndex)
-    
-    // Ordered flattened data
-    var flatStrings []string
+	ki := 0
+	for key, _ := range flattened {
+		kIndex[ki] = key
+		ki++
+	}
+	sort.Strings(kIndex)
+	
+	// Ordered flattened data
+	var flatStrings []string
 	for _, value := range kIndex {
 		flatStrings = append(flatStrings,fmt.Sprintf("\"%v\": %v\n", value, flattened[value]))
 	}
@@ -786,8 +786,8 @@ func main() {
 					}
 				
 					flattened := flattenAndFormatJSON(results)
-				    
-				    // Print the flattened data
+					
+					// Print the flattened data
 					fmt.Println(*flattened)
 				}
 			} else if *conf_json_flat && *conf_rawoutput {


### PR DESCRIPTION
NOTE: Patch is against current master. I will update it if other pulls are merged first.

Outputs the JSON in a flattened state. This is very useful for grepping the output, and is a precursor to allowing mapped CSV output (e.g. for SSLPulse).

Snippet:

> "endpoints.0.grade": "A"
>  "endpoints.0.hasWarnings": false
>  "endpoints.0.ipAddress": "384.257.412.631"
>  "endpoints.0.isExceptional": false
>  "endpoints.0.progress": 100
>  "endpoints.0.serverName": "blahblahblah.amazonaws.com"
>  "endpoints.0.statusMessage": "Ready"
>  "engineVersion": "1.11.8"
>  "host": "testing.yoursite.com"
>  "isPublic": false
>  "port": 443
>  "protocol": "HTTP"
>  "status": "READY"
