### PR TITLE
Added -usecache which will request a cached report from the API servers

### DIFF
--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -447,6 +447,7 @@ func NewAssessment(host string, eventChannel chan Event) {
 
 		if startTime == -1 {
 			startTime = myResponse.StartTime
+			clearCache = false
 		} else {
 			if myResponse.StartTime != startTime {
 				log.Fatalf("[ERROR] Inconsistent startTime. Expected %v, got %v.", startTime, myResponse.StartTime)


### PR DESCRIPTION
Cleaned up version of previously discussed patchset that properly tracks the startTime across iterations and dies on deviations.
