### PR TITLE
This fixes ssllabs/ssllabs-scan#21 and pre-emptively fixes the next

### DIFF
--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -816,7 +816,17 @@ func main() {
 				
 			} else if *conf_rawoutput {
 				// Raw (non-Go-mangled) JSON output
-				fmt.Println(manager.results.responses)
+				
+				fmt.Println("[")
+				for i := range manager.results.responses {
+					results := manager.results.responses[i]
+
+					if i>0 {
+						fmt.Println(",")
+					}
+					fmt.Println(results)
+				}
+				fmt.Println("]")
 			} else {
 				// Regular JSON output
 				results, err = json.Marshal(manager.results.reports)


### PR DESCRIPTION
error the user would have reported, as the result would not have been a
valid JSON array.
