### PR TITLE
cast numbers into int form for flat JSON output, fixes #98

### DIFF
--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -711,7 +711,7 @@ func flattenJSON(inputJSON map[string]interface{}, rootKey string, flattened *ma
 		if _, ok := value.(string); ok {
 			(*flattened)[key] = Q + value.(string) + Q
 		} else if _, ok := value.(float64); ok {
-			(*flattened)[key] = value.(float64)
+			(*flattened)[key] = fmt.Sprintf("%.f", value)
 		} else if _, ok := value.(bool); ok {
 			(*flattened)[key] = value.(bool)
 		} else if _, ok := value.([]interface{}); ok {


### PR DESCRIPTION
When interpreting JSON the way it is done here, type information is not used, but JSON numbers are cast into float64. This results in strange output format for large numbers, such as times (in the Unix timestamp format) being displayed with base+exponential representation (e.g. "1.427376789671e+12") (issue #98)

The API interface does not actually have any float64 numbers, only int/int64, thus, at least at this point, it is safe to cast everly float64 found into int by using a 0-precision representation.

On the long term, a better solution would be to unmarshal the API response using the LabsResponse struct, and iterate over that to create a flattened JSON output. This would needs more refactoring, but would correctly infer the types of every field. (See some hints for this change at [StackOverflow](http://stackoverflow.com/questions/22343083/json-marshaling-with-long-numbers-in-golang-gives-floating-point-number)).