### PR TITLE
Support comment lines

### DIFF
--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -878,7 +878,10 @@ func readLines(path *string) ([]string, error) {
 	var lines []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+		var line = strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "#") {
+			lines = append(lines, line)
+		}
 	}
 	return lines, scanner.Err()
 }

--- a/ssllabs-scan.go
+++ b/ssllabs-scan.go
@@ -879,7 +879,7 @@ func readLines(path *string) ([]string, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		var line = strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "#") {
+		if (!strings.HasPrefix(line, "#")) && (line != "") {
 			lines = append(lines, line)
 		}
 	}


### PR DESCRIPTION
#305 Updated readLines() to do the following:

- Trim whitespace from beginning and end of line
- Filter out lines that start with the comment character #
