### PR TITLE
Minor changes to support markdown on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ join the ssllabs-devel mailing list: https://sourceforge.net/p/ssllabs/mailman/s
 Before you use this tool please review the terms and conditions, which can be found here:
 https://www.ssllabs.com/about/terms.html
 
-##Requirements
+## Requirements
 
 * Go >= 1.3
 
-##Usage 
+## Usage 
 
 SYNOPSIS
 ```
@@ -43,7 +43,7 @@ OPTIONS
 | --grade     | false         | Output only the hostname: grade |
 | --hostcheck | false         | If true, host resolution failure will result in a fatal error |
 
-##Using behind a web Proxy
+## Using behind a web Proxy
 
 Linux/Unix:
 ```
@@ -57,11 +57,11 @@ Windows:
 
 The rules of Go's ProxyFromEnvironment apply (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, lowercase variants allowed).
 
-##Third-Party Tools and Libraries
+## Third-Party Tools and Libraries
 
 A list of libraries and tools that rely on the SSL Labs APIs can be found on the SSL Labs web site: https://www.ssllabs.com/projects/ssllabs-apis/
 
-##Docker
+## Docker
 
 Docker images for this project are available at:
 


### PR DESCRIPTION
GitHub require space between hashtag and title.