### PR TITLE
Updated typo in ssllabs-api-docs-v4.md

### DIFF
--- a/ssllabs-api-docs-v4.md
+++ b/ssllabs-api-docs-v4.md
@@ -102,7 +102,7 @@ Header:
 
 Example:
 
-* `curl --location 'https://<SSLLABS_HOSTNAME>/api/v4/analyze?host=www.ssllabs.com&s=173.203.82.166' --header 'email: jdoe@someoraganizationemail.com'`
+* `curl --location 'https://<SSLLABS_HOSTNAME>/api/v4/getEndpointData?host=www.ssllabs.com&s=173.203.82.166' --header 'email: jdoe@someoraganizationemail.com'`
 
 #### Retrieve known status codes ####
 


### PR DESCRIPTION
fixed example for "getEndpointData" api call. changed "analyze?host=...." to "getEndpointData?host=...."